### PR TITLE
Fix cpp instructions for compilation with R14

### DIFF
--- a/c_src/erl_nif_compat.h
+++ b/c_src/erl_nif_compat.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #endif /* R13B04 */
 
-#if ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION == 0
+#if ERL_NIF_MAJOR_VERSION == 2
 
 #define enif_open_resource_type_compat(E, N, D, F, T) \
     enif_open_resource_type(E, NULL, N, D, F, T)


### PR DESCRIPTION
R14's erl_nif API is not only 2.0 but also 2.1 and 2.2, only the major version
should be checked.
